### PR TITLE
Adjustments to allow for the replacement of Sessions with Strange

### DIFF
--- a/src/actions/cabinet.js
+++ b/src/actions/cabinet.js
@@ -5,12 +5,15 @@ import {
 import {
   getVotes,
   getVoteRecords,
+  getSenators,
 } from '../services/govTrack';
 
 export const GET_VOTES_FAILED = 'GET_VOTES_FAILED';
 export const GET_VOTES_SUCCEEDED = 'GET_VOTES_SUCCEEDED';
 export const GET_VOTE_RECORDS_FAILED = 'GET_VOTE_RECORDS_FAILED';
 export const GET_VOTE_RECORDS_SUCCEEDED = 'GET_VOTE_RECORDS_SUCCEEDED';
+export const GET_SENATORS_FAILED = 'GET_SENATORS_FAILED';
+export const GET_SENATORS_SUCCEEDED = 'GET_SENATORS_SUCCEEDED';
 
 export const getVotesSucceeded = (votes) => {
   return { type: GET_VOTES_SUCCEEDED, payload: { votes } };
@@ -28,26 +31,37 @@ export const getVoteRecordsFailed = (err) => {
   return { type: GET_VOTE_RECORDS_FAILED, payload: { errors: [err] } };
 };
 
+export const getSenatorsSucceeded = (senators) => {
+  return { type: GET_SENATORS_SUCCEEDED, payload: { senators } };
+};
+
+export const getSenatorsFailed = (err) => {
+  return { type: GET_SENATORS_FAILED, payload: { errors: [err] } };
+};
+
 export const getCabinetAsync = () => {
   return (dispatch) => {
     dispatch(loadingStarted());
 
-    return getVotes()
-      .then((votes) => {
-        dispatch(getVotesSucceeded(votes));
+    return Promise.all([
+      getVotes(),
+      getSenators(),
+    ]).then(([votes, senators]) => {
+      dispatch(getSenatorsSucceeded(senators));
+      dispatch(getVotesSucceeded(votes));
 
-        return Promise.all(votes.map((vote) => {
-          return getVoteRecords(vote.id)
-            .then(voteRecords => dispatch(getVoteRecordsSucceeded(voteRecords)))
-            .catch(err => dispatch(getVoteRecordsFailed(err)));
-        }));
-      })
-      .then(() => {
-        dispatch(loadingEnded());
-      })
-      .catch((err) => {
-        dispatch(loadingEnded());
-        dispatch(getVotesFailed(err));
-      });
+      return Promise.all(votes.map((vote) => {
+        return getVoteRecords(vote.id)
+          .then(voteRecords => dispatch(getVoteRecordsSucceeded(voteRecords)))
+          .catch(err => dispatch(getVoteRecordsFailed(err)));
+      }));
+    })
+    .then(() => {
+      dispatch(loadingEnded());
+    })
+    .catch((err) => {
+      dispatch(loadingEnded());
+      dispatch(getVotesFailed(err));
+    });
   };
 };

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -13,6 +13,7 @@ import News from './News';
 const mapStateToProps = state => ({
   votes: state.votes,
   voteRecords: state.voteRecords,
+  senators: state.senators,
   voteTotals: state.voteTotals,
   filterTerm: state.filterTerm,
 });
@@ -31,6 +32,7 @@ class Main extends Component {
     const {
       votes,
       voteRecords,
+      senators,
       voteTotals,
       filterTerm,
       updateFilterTermAsync, // eslint-disable-line no-shadow
@@ -39,26 +41,21 @@ class Main extends Component {
     const partyRegexp = new RegExp(party || '.+', 'i');
     const filterRegexp = new RegExp(filterTerm, 'i');
 
-    const filteredVoteRecords = {};
-    Object.entries(voteRecords).forEach(([voteId, votersForVote]) => {
-      filteredVoteRecords[voteId] = votersForVote
-        .filter(voter => voter.party.match(partyRegexp))
-        .filter((voter) => {
-          return voter.name.match(filterRegexp) ||
-            voter.state.match(filterRegexp) ||
-            voter.stateFull.match(filterRegexp);
-        });
-    });
-
-    const senators = Object.values(filteredVoteRecords)[0] || [];
+    const filteredSenators = senators
+      .filter(senator => senator.party.match(partyRegexp))
+      .filter((senator) => {
+        return senator.name.match(filterRegexp) ||
+          senator.state.match(filterRegexp) ||
+          senator.stateFull.match(filterRegexp);
+      });
 
     return (
       <div className={ data }>
         <Header />
         <TableWrapper
           votes={ votes }
-          senators={ senators }
-          filteredVoteRecords={ filteredVoteRecords }
+          senators={ filteredSenators }
+          voteRecords={ voteRecords }
           voteTotals={ voteTotals }
         >
           <FilterByParty />

--- a/src/components/TableWrapper.js
+++ b/src/components/TableWrapper.js
@@ -47,9 +47,9 @@ const headerize = (text) => {
 
 export default class TableWrapper extends Component {
   render() {
-    const { senators, votes, voteTotals, filteredVoteRecords, children } = this.props;
+    const { senators, votes, voteTotals, voteRecords, children } = this.props;
 
-    let tableWidth = (Object.entries(filteredVoteRecords).length * 62) + (200 + 50 + 40 + 70) + 120;
+    let tableWidth = (Object.entries(voteRecords).length * 62) + (200 + 50 + 40 + 70) + 120;
     if (tableWidth < window.innerWidth) {
       tableWidth = window.innerWidth;
     }
@@ -129,15 +129,17 @@ export default class TableWrapper extends Component {
               );
             } }
           />
-          { Object.entries(filteredVoteRecords).map(([voteId, votersForVote]) => {
+          { Object.entries(voteRecords).map(([voteId, votersForVote]) => {
             return (
               <Column // The vote on each nominee
                 key={ voteId }
                 width={ 62 }
                 header={ () => <Cell className={ cell }>{ headerize(votes[voteId].question) }</Cell> }
                 cell={ (props) => {
-                  if (votersForVote[props.rowIndex]) {
-                    const vote = votersForVote[props.rowIndex].value;
+                  const senator = senators[props.rowIndex];
+
+                  if (votersForVote[senator.id]) {
+                    const vote = votersForVote[senator.id].value;
                     return (
                       <Cell className={ classnames(cellCenter, voteClass(vote)) }>
                         <span>{ voteRepr(vote) }</span>

--- a/src/reducers/errors.js
+++ b/src/reducers/errors.js
@@ -1,13 +1,19 @@
 import {
   GET_VOTES_FAILED,
   GET_VOTE_RECORDS_FAILED,
+  GET_SENATORS_FAILED,
 } from '../actions/cabinet';
 
 export default (state = [], action) => {
   switch (action.type) {
   case GET_VOTES_FAILED:
+    console.trace(action.payload.errors[0]);
     return [...action.payload.errors, ...state];
   case GET_VOTE_RECORDS_FAILED:
+    console.trace(action.payload.errors[0]);
+    return [...action.payload.errors, ...state];
+  case GET_SENATORS_FAILED:
+    console.trace(action.payload.errors[0]);
     return [...action.payload.errors, ...state];
   default:
     return state;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -2,6 +2,7 @@ import { combineReducers } from 'redux';
 
 import votes from './votes';
 import voteRecords from './voteRecords';
+import senators from './senators';
 import voteTotals from './voteTotals';
 import errors from './errors';
 import loading from './loading';
@@ -11,6 +12,7 @@ export default combineReducers({
   loading,
   votes,
   voteRecords,
+  senators,
   voteTotals,
   errors,
   filterTerm,

--- a/src/reducers/senators.js
+++ b/src/reducers/senators.js
@@ -1,0 +1,10 @@
+import { GET_SENATORS_SUCCEEDED } from '../actions/cabinet';
+
+export default (state = [], action) => {
+  switch (action.type) {
+  case GET_SENATORS_SUCCEEDED:
+    return action.payload.senators;
+  default:
+    return state;
+  }
+};

--- a/src/reducers/voteRecords.js
+++ b/src/reducers/voteRecords.js
@@ -8,10 +8,10 @@ export default (state = {}, action) => {
       ...action.payload.voteRecords.reduce((red, cur) => {
         let newRed = red;
         if (red[cur.voteId]) {
-          newRed[cur.voteId] = [cur, ...red[cur.voteId]];
+          newRed[cur.voteId][cur.id] = cur;
         } else {
           newRed = {
-            [cur.voteId]: [cur],
+            [cur.voteId]: { [cur.id]: cur },
             ...red,
           };
         }


### PR DESCRIPTION
All of Sessions' old votes + the lack of new ones for Strange were going to make things blow up the first time he voted on something. (due to me building the data model in a very dumb way)

Now we have three data models:
- `senators` (array of senator objects, with biographical info, etc)
- `votes` (object where keys correspond to the IDs of each vote on a nominee so far)
- `voteRecords` (object where keys correspond to the ids of each vote, then in that object, the keys correspond to senator IDs and contain the information about how they voted

Also the voteTotals, which haven't changed.

Side note, this makes it easier to migrate to the ProPublica API, because we weren't previously doing a separate API call for senator bio information (just relying on the fact that GovTrack returns it in the vote data) and ProPublica requires that.